### PR TITLE
Fix link to API explorer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # api-rest-onvideo
 
-Visit our API Explorer for documentation: https://bluejeans.github.io/api-rest-onvideo/site/index.html
+Visit our API Explorer for documentation: https://bluejeans.github.io/api-rest-meetings/site/index.html
 
 ## C#
 


### PR DESCRIPTION
The link to the API explorer, currently, doesn't redirect to the new URL